### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 # saltant
 
-**saltant** at its core is a
+**saltant** is a
 [Celery](https://github.com/celery/celery)-powered [Django
 app](https://docs.djangoproject.com/en/2.0/ref/applications/) for
-running and managing asynchonous tasks with the philosophy that when you
+running and managing asynchonous tasks. Its philosophy is that when you
 update your task code, you should **never** have to restart your job
-queue/workers, or migrate your backend's database. It's a great solution
+queue/workers, or migrate your backend's database. It is a great solution
 for an ever-changing code base when downtime is expensive.
 
 ## Origin
@@ -22,13 +22,13 @@ saltant is a mutant strain of
 [Tantalus](https://github.com/shahcompbio/tantalus), which served a dual
 role as a task runner (just like saltant) and as a genomics
 file/metadata database for the [Shah Lab](http://shahlab.ca/) at [BC
-Cancer](http://www.bccancer.bc.ca/). The problem with Tantalus was that
-tasks needed frequent updating, and that ever-changing server
-infrastructure required changes in to the job infrastructure—both of
-which usually meant bringing the backend down. When the backend went
-down to sort out task problems, the file/metadata database part had to
-go down too. Therefore there was much to be gained from decoupling the job
-system from the file/metadata database system. Hence, saltant.
+Cancer](http://www.bccancer.bc.ca/). The problems with Tantalus were that
+tasks needed frequent updating and that changes constantly needed to be 
+made in the server infrastructure. Often, these problems usually required 
+bringing the backend down. When the backend was brought down, the 
+file/metadata database part had to go down too. Thus, there was much to be 
+gained from decoupling the job system from the file/metadata database system.
+Hence, saltant.
 
 ## More!
 


### PR DESCRIPTION
- Removed redundant words/phrases
- Separated run-on sentences into two sentences
- "it's" -> "it is"
- "problem" and "was" -> "problems" and "were"
- Removed unnecessary comma
- Edited sentences to improve flow